### PR TITLE
Allow some type aliases to be cast to

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sql-type"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Jakob Truelsen <antialize@gmail.com>"]
 keywords = [ "mysql", "sql", "typer" ]

--- a/src/type_expression.rs
+++ b/src/type_expression.rs
@@ -316,14 +316,15 @@ pub(crate) fn type_expression<'a, 'b>(
                 | sql_parse::Type::Date
                 | sql_parse::Type::DateTime(_)
                 | sql_parse::Type::Double(_)
+                | sql_parse::Type::Float8
                 | sql_parse::Type::Float(_)
                 | sql_parse::Type::Integer(_)
+                | sql_parse::Type::Int(_)
                 | sql_parse::Type::Binary(_)
                 | sql_parse::Type::Time(_) => {}
                 sql_parse::Type::Boolean
                 | sql_parse::Type::TinyInt(_)
                 | sql_parse::Type::SmallInt(_)
-                | sql_parse::Type::Int(_)
                 | sql_parse::Type::BigInt(_)
                 | sql_parse::Type::VarChar(_)
                 | sql_parse::Type::TinyText(_)
@@ -332,7 +333,6 @@ pub(crate) fn type_expression<'a, 'b>(
                 | sql_parse::Type::LongText(_)
                 | sql_parse::Type::Enum(_)
                 | sql_parse::Type::Set(_)
-                | sql_parse::Type::Float8
                 | sql_parse::Type::Numeric(_, _, _)
                 | sql_parse::Type::Timestamp(_)
                 | sql_parse::Type::TinyBlob(_)


### PR DESCRIPTION
We sometimes spell the integer type as `INT` rather than `INTEGER` when casting to it, and MariaDB allows these spellings/aliases when casting.

I have tested that casting to `INT` and `FLOAT8` is allowed.

- https://mariadb.com/kb/en/int/ states that `INTEGER` is a synonym for `INT`.
- https://mariadb.com/docs/reference/mdb/data-types/DOUBLE/ (Enterprise documentation) states that `FLOAT8` and `REAL` are synonym for `DOUBLE`, but for some reason you can cast to `FLOAT8` but not `REAL` (see below).
- https://mariadb.com/kb/en/ never defines `FLOAT8`.

So it is a bit hard to blindly follow the documentation...

Here is a session:

```
MariaDB [scalgo]> SELECT CAST('7' AS integer);
+----------------------+
| CAST('7' AS integer) |
+----------------------+
|                    7 |
+----------------------+
1 row in set (0.000 sec)

MariaDB [scalgo]> SELECT CAST('7' AS int);
+------------------+
| CAST('7' AS int) |
+------------------+
|                7 |
+------------------+
1 row in set (0.000 sec)

MariaDB [scalgo]> SELECT CAST('7.3E+1' AS double);
+--------------------------+
| CAST('7.3E+1' AS double) |
+--------------------------+
|                       73 |
+--------------------------+
1 row in set (0.000 sec)

MariaDB [scalgo]> SELECT CAST('7.3E+1' AS float8);
+--------------------------+
| CAST('7.3E+1' AS float8) |
+--------------------------+
|                       73 |
+--------------------------+
1 row in set (0.000 sec)

MariaDB [scalgo]> SELECT CAST('7.3E+1' AS real);
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'real)' at line 1

MariaDB [scalgo]> status
--------------
mysql  Ver 15.1 Distrib 10.8.3-MariaDB, for Linux (x86_64) using readline 5.1

Connection id:		35877
Current database:	scalgo
Current user:		root@127.0.0.1
SSL:			Not in use
Current pager:		stdout
Using outfile:		''
Using delimiter:	;
Server:			MariaDB
Server version:		10.8.3-MariaDB-1:10.8.3+maria~jammy mariadb.org binary distribution
Protocol version:	10
Connection:		127.0.0.1 via TCP/IP
Server characterset:	utf8mb4
Db     characterset:	utf8mb4
Client characterset:	utf8mb3
Conn.  characterset:	utf8mb3
TCP port:		9745
Uptime:			6 days 23 hours 30 min 58 sec

Threads: 6  Questions: 3157995  Slow queries: 0  Opens: 208  Open tables: 181  Queries per second avg: 5.236
--------------
```